### PR TITLE
Calculate payout from paidCashback

### DIFF
--- a/Shoop.lua
+++ b/Shoop.lua
@@ -146,11 +146,15 @@ function RefreshAccount (account, since)
 
     for i, row in ipairs(response.message.data) do
         if row.status ~= "blocked" then
+            local paidCashback = 0
+            for ti, value in pairs(row.transactions) do
+                paidCashback = paidCashback + value.paidCashback
+            end
             local transaction = {
                 bookingDate = strToDate(row.date),
                 valueDate   = strToDate(row.date),
                 name        = "Auszahlung",
-                amount      = -row.amount,
+                amount      = -paidCashback,
                 currency    = "EUR",
                 booked      = true,
                 purpose     = row.methodLabel


### PR DESCRIPTION
Probably due to the API upgrades, after updating to the latest version coupon payouts are booked by the coupon value instead of the paid value. (This also caused duplicate entries.)
For example a coupon with a price of `9 €` and a value of `10 €` was booked as `-9 €`, but is now booked as `-10 €`.
This commit fixes this behaviour and calculates the value by the transactions related to the coupon.